### PR TITLE
Issue/24

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -72,12 +72,14 @@ multiplier_dict = {
 }
 
 
-def read(file):
+def read(file, software_cycle_number=False):
     """
     Function read electrochemical data from a Neware nda binary file.
 
     Args:
         file (str): Name of a .nda file to read
+        software_cycle_number (bool): Generate the cycle number field
+        to match old versions of BTSDA
     Returns:
         df (pd.DataFrame): DataFrame containing all records in the file
     """
@@ -150,7 +152,8 @@ def read(file):
 
     # Postprocessing
     df['Step'] = _count_changes(df['Step'])
-    df['Cycle'] = _generate_cycle_number(df)
+    if software_cycle_number:
+        df['Cycle'] = _generate_cycle_number(df)
     df = df.astype(dtype=dtype_dict)
 
     return df
@@ -167,7 +170,7 @@ def _bytes_to_list(bytes):
     """Helper function for interpreting a byte string"""
 
     # Extract fields from byte string
-    [Index, Cycle] = struct.unpack('<IB', bytes[2:7])
+    [Index, Cycle] = struct.unpack('<II', bytes[2:10])
     [Step] = struct.unpack('<I', bytes[10:14])
     [Status, Jump, Time] = struct.unpack('<BBQ', bytes[12:22])
     [Voltage, Current] = struct.unpack('<ii', bytes[22:30])

--- a/bin/NewareNDA-cli.py
+++ b/bin/NewareNDA-cli.py
@@ -24,9 +24,11 @@ if __name__ == '__main__':
     parser.add_argument('out_file', help='output file')
     parser.add_argument('-f', '--format', default='csv',
                         choices=output_cmd.keys())
+    parser.add_argument('-s', '--software_cycle_number', action='store_true',
+                        help='Generate the cycle number field to match old versions of BTSDA.')
     parser.add_argument('-v', '--version', help='show version',
                         action='version', version=NewareNDA.__version__)
     args = parser.parse_args()
 
-    df = NewareNDA.read(args.in_file)
+    df = NewareNDA.read(args.in_file, args.software_cycle_number)
     output_cmd[args.format](df, args.out_file)


### PR DESCRIPTION
Adds a new flag which can be used to enable legacy software calculation of the cycle number. This behavior changed in BTSDA 20221226, with the cycle number now being reported directly from the nda file.