### PR TITLE
Add constant power steps to state_dict

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -178,7 +178,7 @@ def _generate_cycle_number(df):
     """
 
     # Identify the beginning of charge steps
-    chg = (df['Status'] == 'CCCV_Chg') | (df['Status'] == 'CC_Chg')
+    chg = (df['Status'] == 'CCCV_Chg') | (df['Status'] == 'CC_Chg') |  (df['Status'] == 'CP_Chg')
     chg = (chg - chg.shift()).clip(0)
     chg.iat[0] = 1
 

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -29,6 +29,7 @@ state_dict = {
     5: 'Cycle',
     7: 'CCCV_Chg',
     8: 'CP_DChg',
+    9: 'CP_Chg',
     10: 'CR_DChg',
     13: 'Pause',
     17: 'SIM',

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -28,6 +28,7 @@ state_dict = {
     4: 'Rest',
     5: 'Cycle',
     7: 'CCCV_Chg',
+    8: 'CP_DChg',
     10: 'CR_DChg',
     13: 'Pause',
     17: 'SIM',


### PR DESCRIPTION
CP DChg type has been tested with two BTS versions, CP Chg was taken from the neware_reader project.

Please let me know if I should switch the PR over against the development branch instead.