### PR TITLE
NewareNDA: try and except remark bytes to ASCII conversion

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -118,13 +118,15 @@ def _read_nda(mm):
     # Get the active mass
     [active_mass] = struct.unpack('<I', mm[152:156])
     logging.info(f"Active mass: {active_mass/1000} mg")
-    
-    # Get the remarks
-    remarks = mm[2317:2417].decode('ASCII')
-    
-    # Clean null characters
-    remarks = remarks.replace(chr(0), '').strip()
-    logging.info(f"Remarks: {remarks}")
+
+    try:
+        remarks = mm[2317:2417].decode('ASCII')
+        # Clean null characters
+        remarks = remarks.replace(chr(0), '').strip()
+        logging.info(f"Remarks: {remarks}")
+    except UnicodeDecodeError:
+        logging.warning(f"Converting remark bytes into ASCII failed")
+        remarks = ""
 
     # Identify the beginning of the data section
     record_len = 86


### PR DESCRIPTION
Some old nda files in my lab have bogus remark bytes (either files have become partially corrupt, or some BTS update has had breaking changes), and trying to convert to ASCII gives an error:

  UnicodeDecodeError: 'ascii' codec can't decode byte 0xa8 in position 10: ordinal not in range(128)

Handle this in NewareNDA and set remarks to empty string if conversion fails.