### PR TITLE
NewareNDA: extract aux voltage as well

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -97,9 +97,8 @@ def read_nda(file, software_cycle_number, cycle_mode='chg'):
     aux_df = pd.DataFrame(aux, columns=aux_columns)
     aux_df.drop_duplicates(inplace=True)
     if not aux_df.empty:
-        pvt_df = aux_df.pivot(index='Index', columns='Aux', values='T')
-        for k in pvt_df.keys():
-            pvt_df.rename(columns={k: f"T{k}"}, inplace=True)
+        pvt_df = aux_df.pivot(index='Index', columns='Aux')
+        pvt_df.columns = pvt_df.columns.map(lambda x: ''.join(map(str, x)))
         df = df.join(pvt_df, on='Index')
 
     # Postprocessing
@@ -278,9 +277,10 @@ def _bytes_to_list_BTS9(bytes):
 def _aux_bytes_to_list(bytes):
     """Helper function for intepreting auxiliary records"""
     [Aux, Index] = struct.unpack('<BI', bytes[1:6])
+    [V] = struct.unpack('<i', bytes[22:26])
     [T] = struct.unpack('<h', bytes[34:36])
 
-    return [Index, Aux, T/10]
+    return [Index, Aux, T/10, V/10000]
 
 
 def _generate_cycle_number(df, cycle_mode='chg'):

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -3,7 +3,7 @@ rec_columns = [
     'Index', 'Cycle', 'Step', 'Status', 'Time', 'Voltage',
     'Current(mA)', 'Charge_Capacity(mAh)', 'Discharge_Capacity(mAh)',
     'Charge_Energy(mWh)', 'Discharge_Energy(mWh)', 'Timestamp']
-aux_columns = ['Index', 'Aux', 'T']
+aux_columns = ['Index', 'Aux', 'T', 'V']
 
 # Define precision of fields
 dtype_dict = {


### PR DESCRIPTION
From checking various files I have access to it seems like both voltage and temperature are always present in the 0x65 entries, but bytes are 0000 if no sensor is connected (or no module is mapped or something).