### PR TITLE
Explict handling by nda/ndc file version

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -77,12 +77,12 @@ def read_nda(file, software_cycle_number, cycle_mode='chg'):
             logging.info("BTS version not found!")
 
         # version specific settings
-        if nda_version == 8:
-            raise NotImplementedError("nda version 8 is not supported!")
-        elif nda_version < 130:
-            output, aux = _read_nda(mm)
-        else:
+        if nda_version == 29:
+            output, aux = _read_nda_29(mm)
+        elif nda_version == 130:
             output, aux = _read_nda_130(mm)
+        else:
+            raise NotImplementedError(f"nda version {nda_version} is not yet supported!")
 
     # Create DataFrame and sort by Index
     df = pd.DataFrame(output, columns=rec_columns)
@@ -111,7 +111,7 @@ def read_nda(file, software_cycle_number, cycle_mode='chg'):
     return df
 
 
-def _read_nda(mm):
+def _read_nda_29(mm):
     """Helper function for older nda verions < 130"""
     mm_size = mm.size()
 

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -271,35 +271,41 @@ def read_ndc(file):
         [ndc_version] = struct.unpack('<B', mm[2:3])
         logging.info(f"NDC version: {ndc_version}")
 
+        if ndc_version == 2:
+            return _read_ndc_2(mm)
         if ndc_version == 5:
             return _read_ndc_5(mm)
         elif ndc_version == 11:
             return _read_ndc_11(mm)
+        else:
+            raise NotImplementedError(f"ndc version {ndc_version} is not yet supported!")
 
-        # Identify the beginning of the data section
-        record_len = 94
-        offset = 0
-        identifier = mm[517:525]
-        id_byte = slice(0, 1)
-        rec_byte = slice(0, 1)
 
-        # Read data records
-        output = []
-        aux = []
-        header = mm.find(identifier)
-        while header != -1:
-            mm.seek(header - offset)
-            bytes = mm.read(record_len)
-            if bytes[rec_byte] == b'\x55':
-                output.append(_bytes_to_list_ndc(bytes))
-            elif bytes[rec_byte] == b'\x65':
-                aux.append(_aux_bytes_65_to_list_ndc(bytes))
-            elif bytes[rec_byte] == b'\x74':
-                aux.append(_aux_bytes_74_to_list_ndc(bytes))
-            else:
-                logging.warning("Unknown record type: "+bytes[rec_byte].hex())
+def _read_ndc_2(mm):
+    """Helper function that reads records and aux data from ndc version 2"""
+    record_len = 94
+    offset = 0
+    identifier = mm[517:525]
+    id_byte = slice(0, 1)
+    rec_byte = slice(0, 1)
 
-            header = mm.find(identifier, header - offset + record_len)
+    # Read data records
+    output = []
+    aux = []
+    header = mm.find(identifier)
+    while header != -1:
+        mm.seek(header - offset)
+        bytes = mm.read(record_len)
+        if bytes[rec_byte] == b'\x55':
+            output.append(_bytes_to_list_ndc(bytes))
+        elif bytes[rec_byte] == b'\x65':
+            aux.append(_aux_bytes_65_to_list_ndc(bytes))
+        elif bytes[rec_byte] == b'\x74':
+            aux.append(_aux_bytes_74_to_list_ndc(bytes))
+        else:
+            logging.warning("Unknown record type: "+bytes[rec_byte].hex())
+
+        header = mm.find(identifier, header - offset + record_len)
 
     # Create DataFrame and sort by Index
     df = pd.DataFrame(output, columns=rec_columns)


### PR DESCRIPTION
Each file version gets its own function, and if a new file version is identified, do not try to read it. Instead raise an error so that it can be manually tested.