### PR TITLE
Specify dtypes for auxiliary fields

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -9,8 +9,8 @@ import logging
 from datetime import datetime, timezone
 import pandas as pd
 
-from NewareNDA.dicts import rec_columns, aux_columns, dtype_dict, \
-    multiplier_dict, state_dict
+from NewareNDA.dicts import rec_columns, dtype_dict, state_dict, \
+    multiplier_dict
 from .NewareNDAx import read_ndax
 
 
@@ -94,7 +94,7 @@ def read_nda(file, software_cycle_number, cycle_mode='chg'):
     df.reset_index(drop=True, inplace=True)
 
     # Join temperature data
-    aux_df = pd.DataFrame(aux, columns=aux_columns)
+    aux_df = pd.DataFrame(aux, columns=['Index', 'Aux', 'T', 'V'])
     aux_df.drop_duplicates(inplace=True)
     if not aux_df.empty:
         pvt_df = aux_df.pivot(index='Index', columns='Aux')

--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -9,8 +9,8 @@ import logging
 from datetime import datetime, timezone
 import pandas as pd
 
-from NewareNDA.dicts import rec_columns, dtype_dict, state_dict, \
-    multiplier_dict
+from NewareNDA.dicts import rec_columns, dtype_dict, aux_dtype_dict, \
+    state_dict, multiplier_dict
 from .NewareNDAx import read_ndax
 
 
@@ -97,6 +97,8 @@ def read_nda(file, software_cycle_number, cycle_mode='chg'):
     aux_df = pd.DataFrame(aux, columns=['Index', 'Aux', 'T', 'V'])
     aux_df.drop_duplicates(inplace=True)
     if not aux_df.empty:
+        aux_df = aux_df.astype(
+            {k: aux_dtype_dict[k] for k in aux_dtype_dict.keys() & aux_df.columns})
         pvt_df = aux_df.pivot(index='Index', columns='Aux')
         pvt_df.columns = pvt_df.columns.map(lambda x: ''.join(map(str, x)))
         df = df.join(pvt_df, on='Index')

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -13,8 +13,8 @@ import xml.etree.ElementTree as ET
 import pandas as pd
 
 import NewareNDA.NewareNDA
-from NewareNDA.dicts import rec_columns, dtype_dict, state_dict, \
-     multiplier_dict
+from NewareNDA.dicts import rec_columns, dtype_dict, aux_dtype_dict, \
+      state_dict, multiplier_dict
 
 
 def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
@@ -92,6 +92,8 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
                 aux['Aux'] = int(m[1])
                 aux_df = pd.concat([aux_df, aux], ignore_index=True)
         if not aux_df.empty:
+            aux_df = aux_df.astype(
+                {k: aux_dtype_dict[k] for k in aux_dtype_dict.keys() & aux_df.columns})
             pvt_df = aux_df.pivot(index='Index', columns='Aux')
             pvt_df.columns = pvt_df.columns.map(lambda x: ''.join(map(str, x)))
             data_df = data_df.join(pvt_df, on='Index')

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -19,6 +19,12 @@ dtype_dict = {
     'Discharge_Energy(mWh)': 'float32'
 }
 
+aux_dtype_dict = {
+    'V': 'float32',
+    'T': 'float32',
+    't': 'float32'
+}
+
 # Dictionary mapping Status integer to string
 state_dict = {
     1: 'CC_Chg',

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -3,7 +3,6 @@ rec_columns = [
     'Index', 'Cycle', 'Step', 'Status', 'Time', 'Voltage',
     'Current(mA)', 'Charge_Capacity(mAh)', 'Discharge_Capacity(mAh)',
     'Charge_Energy(mWh)', 'Discharge_Energy(mWh)', 'Timestamp']
-aux_columns = ['Index', 'Aux', 'T', 'V']
 
 # Define precision of fields
 dtype_dict = {


### PR DESCRIPTION
Introduces a dictionary in dicts.py for specifying the dtype of aux fields. The default is now float32 for a space savings.

@Grimler91 it would be great to get your help with testing.