### PR TITLE
Refactor read_ndc() code

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -169,7 +169,7 @@ def read_ndc(file):
         # Get ndc file version and filetype
         [ndc_filetype] = struct.unpack('<B', mm[0:1])
         [ndc_version] = struct.unpack('<B', mm[2:3])
-        logger.info(f"NDC version: {ndc_version} filetype: {ndc_filetype}")
+        logger.debug(f"NDC version: {ndc_version} filetype: {ndc_filetype}")
 
         try:
             f = getattr(NewareNDA.NewareNDAx, f"_read_ndc_{ndc_version}_filetype_{ndc_filetype}")


### PR DESCRIPTION
Introduces an explicit naming scheme for reading ndc files based on ndc version and filetype numbers. `read_ndc()` chooses the correct function to call and returns a NotImplementedError if it doesn't exist. This will make adding support for new files much easier in the future.