### PR TITLE
Add NDAx class for storing the ndax data and metadata, and fix timezone aware timestamps

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -53,15 +53,17 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
             if 'MainXwjVer' in config.attrib:
                 logger.info(f"Tester version: {config.attrib['MainXwjVer']}")
 
-        # Read active mass
-        try:
+        # Read active mass.
+        # TODO: if test is edited while running then there are
+        # Step{1,2,3,..}.xml files. We should perhaps check the newest
+        # one rather than Step.xml in case active mass was changed.
+        if 'Step.xml' in filelist:
             step = zf.extract('Step.xml', path=tmpdir)
             with open(step, 'r', encoding='gb2312') as f:
                 config = ET.fromstring(f.read()).find('config')
-            active_mass = float(config.find('Head_Info/SCQ').attrib['Value'])
-            logger.info(f"Active mass: {active_mass/1000} mg")
-        except Exception:
-            pass
+            if 'Head_Info/SCQ' in config.attrib:
+                active_mass = float(config.find('Head_Info/SCQ').attrib['Value'])
+                logger.info(f"Active mass: {active_mass/1000} mg")
 
         # Read aux channel mapping and test information from
         # TestInfo.xml

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -92,7 +92,7 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
                 aux_ch_dict.update({int(aux.attrib['RealChlID']): int(aux.attrib['AuxID'])})
 
         # Try to read data.ndc
-        if 'data.ndc' in zf.namelist():
+        if 'data.ndc' in filelist:
             data_file = zf.extract('data.ndc', path=tmpdir)
             data_df = read_ndc(data_file)
         else:
@@ -101,7 +101,7 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
         # Some ndax have data spread across 3 different ndc files. Others have
         # all data in data.ndc.
         # Check if data_runInfo.ndc and data_step.ndc exist
-        if all(i in zf.namelist() for i in ['data_runInfo.ndc', 'data_step.ndc']):
+        if all(i in filelist for i in ['data_runInfo.ndc', 'data_step.ndc']):
 
             # Read data from separate files
             runInfo_file = zf.extract('data_runInfo.ndc', path=tmpdir)
@@ -121,7 +121,7 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
 
         # Read and merge Aux data from ndc files
         aux_df = pd.DataFrame([])
-        for f in zf.namelist():
+        for f in filelist:
 
             # If the filename contains a channel number, convert to aux_id
             m = re.search("data_AUX_([0-9]+)_[0-9]+_[0-9]+[.]ndc", f)

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -39,16 +39,19 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
         filelist = zf.namelist()
 
         # Read version information
-        try:
+        if 'VersionInfo.xml' in filelist:
             version_info = zf.extract('VersionInfo.xml', path=tmpdir)
             with open(version_info, 'r', encoding='gb2312') as f:
                 config = ET.fromstring(f.read()).find('config/ZwjVersion')
-            logger.info(f"Server version: {config.attrib['SvrVer']}")
-            logger.info(f"Client version: {config.attrib['CurrClientVer']}")
-            logger.info(f"Control unit version: {config.attrib['ZwjVersion']}")
-            logger.info(f"Tester version: {config.attrib['MainXwjVer']}")
-        except Exception:
-            pass
+
+            if 'SvrVer' in config.attrib:
+                logger.info(f"Server version: {config.attrib['SvrVer']}")
+            if 'CurrClientVer' in config.attrib:
+                logger.info(f"Client version: {config.attrib['CurrClientVer']}")
+            if 'ZwjVersion' in config.attrib:
+                logger.info(f"Control unit version: {config.attrib['ZwjVersion']}")
+            if 'MainXwjVer' in config.attrib:
+                logger.info(f"Tester version: {config.attrib['MainXwjVer']}")
 
         # Read active mass
         try:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,19 @@ pip install .
 # Usage
 ```
 import NewareNDA
-df = NewareNDA.read('filename.nda')
+df = NewareNDA.read('filename.nda(x)')
+```
+
+If you are only dealing with ndax files you can also import an NDAx class, and get access to metadata:
+
+```
+from NewareNDA.NewareNDAx import NDAx
+
+ndax = NDAx('filename.ndax')
+ndax_file.read_ndax()
+data = ndax_file.data_df
+# Test parameters like ndax_file.{barcode,active_mass,PN,start_time} can now be accessed,
+# and test equipment parameters like ndax_file.{server,client,control_unit,tester}_version
 ```
 
 ## Logging


### PR DESCRIPTION
To fix Solid-Energy-Systems/NewareNDA#96 I needed to access StartTime from TestInfo.xml in the read_ndc functions. Rather than passing StartTime to all of the read_ndc functions I think it is clearer to add a class for storing this information, and accessing the StartTime as an internal variable there.

The changes are backward compatible, so 

```
import NewareNDA

data = NewareNDA.read('filename.ndax')
```

still work, but for accessing the metadata variables one can now also use the class through:

```
from NewareNDA.NewareNDAx import NDAx

ndax_file = NDAx('filename.ndax')
ndax_file.read_ndax()
data = ndax_file.data_df
print(ndax_file.active_mass)
print(ndax_file.barcode)
...
```

It only works for .ndax at the moment, but if you approve of this approach then I can work on converting NewareNDA.py in a similar way.

The diff is quite huge in github's UI, but a large part of it is just indenting and moving the code into the new class, and github's UI is not clever enough to detect this. To get a diff that is a bit easier to review you can checkout this branch locally and run `git diff --ignore-space-change origin/development`.

Regarding the timestamp fix:
StartTime in TestInfo.xml is in local time of test equipment (without any timezone indication), and can be compared with the first timestamp in the file to figure out what shift we should use. I round the difference to nearest half an hour and add the diff to all timestamps.
With these changes I get the same behaviour with both NewareNDA and BTSDA.

Fixes: Solid-Energy-Systems/NewareNDA#96

One sidenote: the ndc_{11,14}_filetype_18 ndc files are aware of milliseconds as well, BTSDA shows non-zero milliseconds for both Time, Total Time and the Date columns if column units are changed to hh:mm:ss.ms. It looks like the milliseconds are stored in the 4 bytes before the Timestamp, but I have not been able to figure out how to decode them. 
For this ndc version the the Time/Total Time and Date column also differs by a few seconds (as in, taking a delta from Date column does not give same result as a delta in Time/Total Time columns), which might be good to know for anyone doing time sensitive stuff.. 