### PR TITLE
dicts: add step type 22: OCV

### DIFF
--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -42,6 +42,7 @@ state_dict = {
     19: 'CV_DChg',
     20: 'CCCV_DChg',
     21: 'Control',
+    22: 'OCV',
     26: 'CPCV_DChg',
     27: 'CPCV_Chg'
 }


### PR DESCRIPTION
22 should be the step type OCV which exists in some BTS versions.

Reported-by: @AndreSihm
Fixes: Solid-Energy-Systems/NewareNDA#100