### PR TITLE
Bugfix timestamp interpolation

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -154,9 +154,9 @@ def _data_interpolation(df):
     df['Time'] = df['Time'].where(nan_mask2, time)
 
     # Fill in missing Timestamps
-    time_inc = df['Time'].diff().groupby(nan_mask.cumsum()).cumsum()
+    time_inc = df['Time'].diff().groupby(nan_mask.shift().cumsum()).cumsum()
     timestamp = df['Timestamp'].ffill() + \
-        pd.to_timedelta(time_inc.shift().fillna(0), unit='s')
+        pd.to_timedelta(time_inc.fillna(0), unit='s')
     df['Timestamp'] = df['Timestamp'].where(nan_mask, timestamp)
 
     # Integrate to get capacity and fill missing values


### PR DESCRIPTION
Thank you for open-sourcing this tool, it is very useful in our lab.

On rare occasions, my timestamps are being interpolated incorrectly and are non-monotonic.

I think there is an issue grouping the nan values when interpolating, and it shows up when nans begin one index after a step change.

```
nan_mask 1 1 1 0 0 0 1 1 1
group    1 2 3 3 3 3 4 5 6
             ^ this index is in the wrong group
```

After a step change, the time diff is negative. If the nan-block starts one index after this, then this negative time difference is included in the sum:

```
nan_mask   1 1  1  0  0  0  1  1  1
group      1 2  3  3  3  3  4  5  6
step       1 1  2  2  2  2  2  2  2
time diff  1 1 -5  1  1  1  1  1  1
time delta 1 1 -5 -4 -3 -2  1  1  1
                   ^  ^  ^ because the previous index is included the time delta is wrong in the nan block
```

The issue is resolved for me when I shift the nan mask before the cumulative sum, giving
```
nan_mask 1 1 1 0 0 0 1 1 1
group    0 1 2 3 3 3 3 4 5
               ^ this is now correct
```
Then the time delta is also correct
```
nan_mask   1 1  1 0 0 0 1 1 1
group      0 1  2 3 3 3 3 4 5
step       1 1  2 2 2 2 2 2 2
time diff  1 1 -5 1 1 1 1 1 1
time delta 1 1 -5 1 2 3 4 1 1
                  ^ ^ ^ the time delta in this nan block is now correct
```
The group now extends one index to the right, but this doesn't matter because that index is dropped in line 160.
```
df['Timestamp'] = df['Timestamp'].where(nan_mask, timestamp)
```
A more correct way might be to group by `(mask != mask.shift()).cumsum()`, but I think it gives identical results.

Below shows a comparison before and after this change:

![image](https://github.com/user-attachments/assets/290d1040-637c-4145-bd58-fb901255aa94)

